### PR TITLE
Add RAP action and utility class for XML HTTP transfer

### DIFF
--- a/rap_file_transfer.abap
+++ b/rap_file_transfer.abap
@@ -1,0 +1,156 @@
+@EndUserText.label: 'File Transfer Parameters'
+define type ZI_FileTransfer_Param {
+  directory     : abap.char(255);
+  file_name     : abap.char(128);
+  target_url    : abap.char(512);
+  proxy_host    : abap.char(255);
+  proxy_service : abap.char(10);
+  auth_user     : abap.char(60);
+  auth_password : abap.char(60);
+}
+
+@EndUserText.label: 'File Transfer Requests'
+@AccessControl.authorizationCheck: #CHECK
+@Metadata.allowExtensions: true
+@AbapCatalog.sqlViewName: 'ZVIFLTRNS'
+define root view entity ZI_FileTransfer
+  provider contract transactional_query
+  as select from zfiletransfer
+{
+  key transfer_uuid      : abap.uuid,
+      directory          : abap.char(255),
+      file_name          : abap.char(128),
+      target_url         : abap.char(512),
+      last_http_status   : abap.int4,
+      last_response_text : abap.string,
+      last_executed_at   : abap.utclong
+}
+
+
+define behavior for ZI_FileTransfer alias FileTransfer
+  persistent table zfiletransfer
+  lock master
+  authorization master ( instance )
+  etag master last_executed_at
+  managed implementation in class zbp_i_filetransfer unique
+{
+  create;
+  update;
+  delete;
+
+  action sendToSFTP parameter ZI_FileTransfer_Param result [1] $self;
+
+  mapping for zfiletransfer
+  {
+    transfer_uuid      = transfer_uuid;
+    directory          = directory;
+    file_name          = file_name;
+    target_url         = target_url;
+    last_http_status   = last_http_status;
+    last_response_text = last_response_text;
+    last_executed_at   = last_executed_at;
+  }
+}
+
+CLASS zbp_i_filetransfer DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC.
+  PUBLIC SECTION.
+    INTERFACES if_abap_behavior_handler.
+ENDCLASS.
+
+CLASS zbp_i_filetransfer IMPLEMENTATION.
+ENDCLASS.
+
+CLASS lhc_FileTransfer DEFINITION
+  INHERITING FROM cl_abap_behavior_handler.
+  PRIVATE SECTION.
+    METHODS sendToSFTP
+      FOR ACTION FileTransfer~sendToSFTP
+      IMPORTING keys FOR ACTION FileTransfer~sendToSFTP
+                parameter parameter
+      RESULT result.
+ENDCLASS.
+
+CLASS lhc_FileTransfer IMPLEMENTATION.
+  METHOD sendToSFTP.
+    DATA ls_param TYPE ZI_FileTransfer_Param.
+    ls_param = parameter.
+
+    LOOP AT keys ASSIGNING FIELD-SYMBOL(<ls_key>).
+      READ ENTITIES OF ZI_FileTransfer IN LOCAL MODE
+        ENTITY FileTransfer
+          FIELDS ( transfer_uuid directory file_name target_url last_http_status last_response_text last_executed_at )
+          WITH VALUE #( ( %tky = <ls_key>-%tky ) )
+        RESULT DATA(lt_transfer).
+
+      IF lt_transfer IS INITIAL.
+        APPEND VALUE #( %tky = <ls_key>-%tky
+                        %msg = new_message_with_text( severity = if_abap_behv_message=>severity-error
+                                                      text     = 'Transfer request not found.' ) )
+          TO failed.
+        CONTINUE.
+      ENDIF.
+
+      DATA(ls_transfer) = lt_transfer[ 1 ].
+
+      DATA(lv_directory) = COND string( WHEN ls_param-directory IS NOT INITIAL THEN ls_param-directory ELSE ls_transfer-directory ).
+      DATA(lv_file_name) = COND string( WHEN ls_param-file_name IS NOT INITIAL THEN ls_param-file_name ELSE ls_transfer-file_name ).
+      DATA(lv_target_url) = COND string( WHEN ls_param-target_url IS NOT INITIAL THEN ls_param-target_url ELSE ls_transfer-target_url ).
+
+      IF lv_directory IS INITIAL OR lv_file_name IS INITIAL OR lv_target_url IS INITIAL.
+        APPEND VALUE #( %tky = <ls_key>-%tky
+                        %msg = new_message_with_text( severity = if_abap_behv_message=>severity-error
+                                                      text     = 'Directory, file name, and target URL are required.' ) )
+          TO failed.
+        CONTINUE.
+      ENDIF.
+
+      TRY.
+          DATA(lv_status) = 0.
+          DATA(lv_response) = ''.
+
+          zcl_send_xml_http=>send_file_to_http(
+            EXPORTING
+              i_directory     = lv_directory
+              i_file_name     = lv_file_name
+              i_target_url    = lv_target_url
+              i_proxy_host    = ls_param-proxy_host
+              i_proxy_service = ls_param-proxy_service
+              i_auth_user     = ls_param-auth_user
+              i_auth_password = ls_param-auth_password
+            IMPORTING
+              e_http_status   = lv_status
+              e_response_body = lv_response ).
+
+          MODIFY ENTITIES OF ZI_FileTransfer IN LOCAL MODE
+            ENTITY FileTransfer
+              UPDATE FIELDS ( last_http_status last_response_text last_executed_at )
+              WITH VALUE #( ( %tky             = <ls_key>-%tky
+                              last_http_status   = lv_status
+                              last_response_text = lv_response
+                              last_executed_at   = cl_abap_context_info=>get_system_date_time( ) ) ).
+
+          APPEND VALUE #( %tky = <ls_key>-%tky ) TO result.
+          APPEND VALUE #( %tky = <ls_key>-%tky
+                          %msg = new_message_with_text( severity = if_abap_behv_message=>severity-success
+                                                        text     = |File { lv_file_name } forwarded to CPI (HTTP { lv_status }).| ) )
+            TO reported.
+        CATCH zcx_file_transfer_error INTO DATA(lx_transfer).
+          MODIFY ENTITIES OF ZI_FileTransfer IN LOCAL MODE
+            ENTITY FileTransfer
+              UPDATE FIELDS ( last_http_status last_response_text last_executed_at )
+              WITH VALUE #( ( %tky             = <ls_key>-%tky
+                              last_http_status   = 0
+                              last_response_text = lx_transfer->get_text( )
+                              last_executed_at   = cl_abap_context_info=>get_system_date_time( ) ) ).
+
+          APPEND VALUE #( %tky = <ls_key>-%tky
+                          %msg = new_message_with_text( severity = if_abap_behv_message=>severity-error
+                                                        text     = lx_transfer->get_text( ) ) )
+            TO failed.
+      ENDTRY.
+    ENDLOOP.
+  ENDMETHOD.
+ENDCLASS.

--- a/zcl_send_xml_http.abap
+++ b/zcl_send_xml_http.abap
@@ -1,0 +1,159 @@
+CLASS zcx_file_transfer_error DEFINITION
+  PUBLIC
+  INHERITING FROM cx_static_check
+  FINAL.
+  PUBLIC SECTION.
+    METHODS constructor
+      IMPORTING
+        msg      TYPE string OPTIONAL
+        previous TYPE REF TO cx_root OPTIONAL.
+ENDCLASS.
+
+CLASS zcx_file_transfer_error IMPLEMENTATION.
+  METHOD constructor.
+    super->constructor( previous = previous ).
+    IF msg IS INITIAL AND previous IS BOUND.
+      me->set_text( previous->get_text( ) ).
+    ELSEIF msg IS NOT INITIAL.
+      me->set_text( msg ).
+    ELSE.
+      me->set_text( 'File transfer error occurred.' ).
+    ENDIF.
+  ENDMETHOD.
+ENDCLASS.
+
+CLASS zcl_send_xml_http DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC.
+  PUBLIC SECTION.
+    CONSTANTS c_content_type_xml TYPE string VALUE 'application/xml'.
+    CLASS-METHODS send_file_to_http
+      IMPORTING
+        i_directory     TYPE string
+        i_file_name     TYPE string
+        i_target_url    TYPE string
+        i_proxy_host    TYPE string OPTIONAL
+        i_proxy_service TYPE string OPTIONAL
+        i_auth_user     TYPE string OPTIONAL
+        i_auth_password TYPE string OPTIONAL
+      EXPORTING
+        e_http_status   TYPE i
+        e_response_body TYPE string
+      RAISING
+        zcx_file_transfer_error.
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+    CLASS-METHODS normalize_directory
+      IMPORTING
+        i_directory TYPE string
+      RETURNING VALUE(r_directory) TYPE string.
+ENDCLASS.
+
+CLASS zcl_send_xml_http IMPLEMENTATION.
+  METHOD normalize_directory.
+    DATA(lv_directory) = cl_abap_string_utilities=>trim( val = i_directory ).
+    IF lv_directory IS INITIAL.
+      r_directory = ''.
+      RETURN.
+    ENDIF.
+
+    DATA(lv_len) = strlen( lv_directory ).
+    IF lv_len = 0.
+      r_directory = ''.
+    ELSEIF lv_directory+lv_len-1 = '/'.
+      r_directory = lv_directory.
+    ELSE.
+      r_directory = |{ lv_directory }/|.
+    ENDIF.
+  ENDMETHOD.
+
+  METHOD send_file_to_http.
+    IF i_directory IS INITIAL OR i_file_name IS INITIAL OR i_target_url IS INITIAL.
+      RAISE EXCEPTION NEW zcx_file_transfer_error(
+        msg = 'Directory, file name, and target URL must be provided.' ).
+    ENDIF.
+
+    DATA(lv_directory) = normalize_directory( i_directory = i_directory ).
+    DATA(lv_full_path) = |{ lv_directory }{ i_file_name }|.
+
+    DATA: lv_payload_line TYPE string,
+          lv_payload      TYPE string,
+          lv_message      TYPE string.
+
+    OPEN DATASET lv_full_path FOR INPUT IN TEXT MODE ENCODING UTF-8 MESSAGE lv_message.
+    IF sy-subrc <> 0.
+      RAISE EXCEPTION NEW zcx_file_transfer_error(
+        msg = |Unable to open file { lv_full_path }: { lv_message }| ).
+    ENDIF.
+
+    TRY.
+        WHILE abap_true.
+          READ DATASET lv_full_path INTO lv_payload_line.
+          IF sy-subrc <> 0.
+            EXIT.
+          ENDIF.
+
+          IF lv_payload IS INITIAL.
+            lv_payload = lv_payload_line.
+          ELSE.
+            CONCATENATE lv_payload cl_abap_char_utilities=>newline lv_payload_line INTO lv_payload.
+          ENDIF.
+        ENDWHILE.
+      CATCH cx_sy_file_access_error INTO DATA(lx_file).
+        CLOSE DATASET lv_full_path.
+        RAISE EXCEPTION NEW zcx_file_transfer_error( previous = lx_file ).
+    ENDTRY.
+
+    CLOSE DATASET lv_full_path.
+
+    IF lv_payload IS INITIAL.
+      RAISE EXCEPTION NEW zcx_file_transfer_error(
+        msg = |File { lv_full_path } is empty.| ).
+    ENDIF.
+
+    DATA(lo_http_client) TYPE REF TO if_http_client.
+
+    TRY.
+        cl_http_client=>create_by_url(
+          EXPORTING
+            url           = i_target_url
+            proxy_host    = i_proxy_host
+            proxy_service = i_proxy_service
+          IMPORTING
+            client        = lo_http_client ).
+      CATCH cx_root INTO DATA(lx_create).
+        RAISE EXCEPTION NEW zcx_file_transfer_error( previous = lx_create ).
+    ENDTRY.
+
+    TRY.
+        lo_http_client->request->set_method( if_http_request=>co_request_method_post ).
+        lo_http_client->request->set_header_field( name = if_http_header_fields_sap=>content_type value = c_content_type_xml ).
+        lo_http_client->request->set_header_field( name = if_http_header_fields_sap=>accept value = c_content_type_xml ).
+
+        IF i_auth_user IS NOT INITIAL.
+          lo_http_client->authenticate( username = i_auth_user password = i_auth_password ).
+        ENDIF.
+
+        lo_http_client->request->set_cdata( data = lv_payload ).
+
+        lo_http_client->send( ).
+        lo_http_client->receive( ).
+
+        lo_http_client->response->get_status( IMPORTING code = e_http_status ).
+        e_response_body = lo_http_client->response->get_cdata( ).
+
+        IF e_http_status < 200 OR e_http_status >= 300.
+          DATA(lv_reason) = lo_http_client->response->get_status_text( ).
+          RAISE EXCEPTION NEW zcx_file_transfer_error(
+            msg = |HTTP error { e_http_status } ({ lv_reason }) while calling { i_target_url }.| ).
+        ENDIF.
+      CATCH cx_root INTO DATA(lx_http).
+        RAISE EXCEPTION NEW zcx_file_transfer_error( previous = lx_http ).
+      FINALLY.
+        IF lo_http_client IS BOUND.
+          lo_http_client->close( ).
+        ENDIF.
+    ENDTRY.
+  ENDMETHOD.
+ENDCLASS.


### PR DESCRIPTION
## Summary
- add a reusable utility class to read XML files from the application server and post them to CPI via HTTP
- define RAP view, parameter structure, behavior, and handler implementation exposing an action that uses the utility

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cc1ce5b93483299c3ff5fc527f60ee